### PR TITLE
Javascript clean up, deciperer added

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
+    "@octokit/rest": "^17.1.1",
     "dotenv": "^8.2.0",
     "firebase": "^7.12.0",
     "sirv-cli": "^0.4.4",

--- a/src/components/providerDeciperer.svelte
+++ b/src/components/providerDeciperer.svelte
@@ -1,0 +1,31 @@
+<script context="module">
+  // Result arg should be from signin in SetUp.svelte!
+  export function providerDeciperer(result) {
+    let userObject = {}
+    // console.log("You've imported me!");
+    // console.log("Hmm, the provider is..." + result.additionalUserInfo.providerId);
+    // console.log(result)
+    // console.log(result.additionalUserInfo.profile)
+    switch (result.additionalUserInfo.providerId) {
+      case "google.com": {
+        // console.log("Profile name from google profile being saved... " + result.additionalUserInfo.profile.name) // Returns a proper name!
+        userObject.username = result.additionalUserInfo.profile.name // Becomes undefined!? Dragon! DRAGONS!
+        // console.log("Profile name saved in userObject... " + userObject.username) // Returns a proper name... What's going on here? Why is it becoming undefined outside of the switch?
+
+        // console.log(result.additionalUserInfo.profile.picture) // Same as above
+        userObject.profilePicture = result.additionalUserInfo.profile.picture // By gods, there's MORE DRAGONS!
+
+        userObject.accessToken = result.credential.accessToken // Do we need the idToken too? (Look at result.credential, it's there under accesstoken.)
+        userObject.refreshToken = result.user.refreshToken // I think the access token up above doesn't have an expire on it... Is this token for firebase auth, not google?
+      }
+      case "github.com": {
+        userObject.username = result.additionalUserInfo.username
+        userObject.profilePicture = result.additionalUserInfo.profile.avatar_url // Big brain time!
+        userObject.accessToken = result.credential.accessToken
+        userObject.refreshToken = result.user.refreshToken
+      }
+    }
+    // console.log(userObject)
+    // Save the userObject into localstorage!
+  }
+</script>

--- a/src/pages/GithubTest.svelte
+++ b/src/pages/GithubTest.svelte
@@ -1,14 +1,25 @@
 <script>
-  import firebase from "@firebase/app";
+  import firebase from '@firebase/app'
   //import { firebaseConfig as config } from '../firebase'
-  import { navigate } from "svelte-routing";
+  import { navigate } from 'svelte-routing'
+  import { Octokit } from '@octokit/rest'
+
+  // STOP THERE, YA UNWARY ONE! Look at issue #6 on the github before reading on!
+  // STOP THERE, YA UNWARY ONE! Look at issue #6 on the github before reading on!
+  // STOP THERE, YA UNWARY ONE! Look at issue #6 on the github before reading on!
 
   firebase.auth().onAuthStateChanged(function(user) {
     if (user.providerData[0].providerId === "github.com") {
-      console.log("Yes, this is github!");
-      let githubToken = user.credential.accessToken; // Throw this token at Github's APIs to get it to play nice with you!
+      console.log("Yes, this is github!")
+      console.log(user)
+      console.log(user.credential)
+      let githubToken = user.refreshToken; // Throw this token at Github's APIs to get it to play nice with you!
+      let octokit = new Octokit({ auth: githubToken }) // Copy paste from issue #6
+      octokit.users.getAuthenticated().then(result => {
+        console.log(result.data.login) // this is the username
+      })
       // start up the github api! Here! Code code codey code code
-      // https://github.com/github-tools/github This seems like a really nice wrapper! It can work with 0auth tokens. 
+      // https://github.com/github-tools/github This seems like a really nice wrapper! It can work with 0auth tokens.
       // https://octokit.github.io/rest.js/v17 I think this is the offical javascript Github API...? Not sure. No one's talking about this.
     } else {
       navigate("/", { replace: true }); // I think this will trigger for GapiTest.svelte... Think about this later. We will need to merge GithibTest and GapiTest.

--- a/src/pages/Setup.svelte
+++ b/src/pages/Setup.svelte
@@ -1,19 +1,20 @@
 <script>
-  import Layout from '../components/Layout.svelte';
+  import Layout from '../components/Layout.svelte'
   import firebase from '@firebase/app'
-  import '../firebase.js';
-  import '@firebase/auth';
+  import '../firebase.js'
+  import '@firebase/auth'
   import { Link } from 'svelte-routing'
+  import { providerDeciperer } from './../components/providerDeciperer.svelte'
   export const language = 'en'
 
   const step = 1
   let user = ''
   let provider = '' // Use this to see which account is signed in.
 
-  const googleProvider = new firebase.auth.GoogleAuthProvider()
+  const googleProvider = new firebase.auth.GoogleAuthProvider() // Maybe move this into the signin function? Pass 'google', 'github', etc string to the function to decide which provider to load up. 
   googleProvider.addScope("https://www.googleapis.com/auth/calendar") // Calendar Permissions
 
-  const githubProvider = new firebase.auth.GithubAuthProvider()
+  const githubProvider = new firebase.auth.GithubAuthProvider() // See line 13 comment.
   githubProvider.addScope("repo")
 
   firebase.auth().onAuthStateChanged(function(u) {
@@ -33,6 +34,8 @@
       .signInWithPopup(provider)
       .then(result => {
         // console.log(result.user) // firebase.auth().onAuthStateChanged(function(u) {... Gets the same stuff.
+        // console.log(result)
+        providerDeciperer(result)
       }) 
   } 
 


### PR DESCRIPTION
This explains the reasoning behind this pull request. https://github.com/Shiroraven/Jikanri/issues/6#issuecomment-602411339

Todo: 

Save the userObject created in providerDeciperer into localStorage for the other .svelte pages to access. Part of #3? Localstorage magic!

Figure out why the hell the additionalUserInfo.profile object from signing into google isn't saving to an object as anything but undefined. (Occurring on line 12 in providerDeciperer.svelt) It works fine if you console.log it from within the switch there, but if you console.log the userObject outside of the switch... The username and picture becomes undefined! (This convinced me to put down my keyboard and go to bed now)