### PR TITLE
Svelte.store functionality added

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,8 @@
+import { writable } from "svelte/store";
+
+export const auth = writable({
+  username: "",
+  profilePicture: "",
+  accessToken: "",
+  refreshToken: ""
+})

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,8 +1,8 @@
-import { writable } from "svelte/store";
+import { writable } from 'svelte/store'
 
 export const auth = writable({
-  username: "",
-  profilePicture: "",
-  accessToken: "",
-  refreshToken: ""
+  username: '',
+  profilePicture: '',
+  accessToken: '',
+  refreshToken: ''
 })

--- a/src/components/providerDeciperer.svelte
+++ b/src/components/providerDeciperer.svelte
@@ -7,7 +7,7 @@
       profilePicture: '',
       accessToken: '',
       refreshToken: ''
-    };
+    }
     // console.log("You've imported me!");
     // console.log("Hmm, the provider is..." + result.additionalUserInfo.providerId);
     switch (result.additionalUserInfo.providerId) {

--- a/src/components/providerDeciperer.svelte
+++ b/src/components/providerDeciperer.svelte
@@ -1,12 +1,12 @@
 <script context="module">
-  import { auth } from "./../auth";
+  import { auth } from './../auth'
   // Result arg should be from signin in SetUp.svelte!
   export function providerDeciperer(result) {
     let authObject = {
-      username: "",
-      profilePicture: "",
-      accessToken: "",
-      refreshToken: ""
+      username: '',
+      profilePicture: '',
+      accessToken: '',
+      refreshToken: ''
     };
     // console.log("You've imported me!");
     // console.log("Hmm, the provider is..." + result.additionalUserInfo.providerId);

--- a/src/components/providerDeciperer.svelte
+++ b/src/components/providerDeciperer.svelte
@@ -1,31 +1,65 @@
 <script context="module">
+  import { auth } from "./../auth";
   // Result arg should be from signin in SetUp.svelte!
   export function providerDeciperer(result) {
-    let userObject = {}
+    let authObject = {
+      username: "",
+      profilePicture: "",
+      accessToken: "",
+      refreshToken: ""
+    };
     // console.log("You've imported me!");
     // console.log("Hmm, the provider is..." + result.additionalUserInfo.providerId);
-    // console.log(result)
-    // console.log(result.additionalUserInfo.profile)
     switch (result.additionalUserInfo.providerId) {
       case "google.com": {
-        // console.log("Profile name from google profile being saved... " + result.additionalUserInfo.profile.name) // Returns a proper name!
-        userObject.username = result.additionalUserInfo.profile.name // Becomes undefined!? Dragon! DRAGONS!
-        // console.log("Profile name saved in userObject... " + userObject.username) // Returns a proper name... What's going on here? Why is it becoming undefined outside of the switch?
-
-        // console.log(result.additionalUserInfo.profile.picture) // Same as above
-        userObject.profilePicture = result.additionalUserInfo.profile.picture // By gods, there's MORE DRAGONS!
-
-        userObject.accessToken = result.credential.accessToken // Do we need the idToken too? (Look at result.credential, it's there under accesstoken.)
-        userObject.refreshToken = result.user.refreshToken // I think the access token up above doesn't have an expire on it... Is this token for firebase auth, not google?
+        authObject.username = result.additionalUserInfo.profile.name;
+        authObject.profilePicture = result.additionalUserInfo.profile.picture;
+        authObject.accessToken = result.credential.accessToken;
+        authObject.refreshToken = result.user.refreshToken;
+        break;
       }
       case "github.com": {
-        userObject.username = result.additionalUserInfo.username
-        userObject.profilePicture = result.additionalUserInfo.profile.avatar_url // Big brain time!
-        userObject.accessToken = result.credential.accessToken
-        userObject.refreshToken = result.user.refreshToken
+        authObject.username = result.additionalUserInfo.username;
+        authObject.profilePicture =
+          result.additionalUserInfo.profile.avatar_url;
+        authObject.accessToken = result.credential.accessToken;
+        authObject.refreshToken = result.user.refreshToken;
+        break;
+      }
+      default: {
+        // console.log("What is this crap are you feeding me!?")
+        break;
       }
     }
-    // console.log(userObject)
-    // Save the userObject into localstorage!
+    auth.update(auth => (auth = authObject)); // I don't like this. See commented out code block below.
+
+    // This below would have been the perfect way for this to be coded! But... For some reason, despite the last console.log(auth) logging an object to the console with all of the fields filled in, if you try to read the $auth object from other pages, you get a undefined object!
+    /* 
+    auth.update(auth => {
+      console.log(auth);
+      switch (result.additionalUserInfo.providerId) {
+        case "google.com": {
+          auth.username = result.additionalUserInfo.profile.name;
+          auth.profilePicture = result.additionalUserInfo.profile.picture;
+          auth.accessToken = result.credential.accessToken;
+          auth.refreshToken = result.user.refreshToken;
+          break;
+        }
+        case "github.com": {
+          auth.username = result.additionalUserInfo.username;
+          auth.profilePicture = result.additionalUserInfo.profile.avatar_url;
+          auth.accessToken = result.credential.accessToken;
+          auth.refreshToken = result.user.refreshToken;
+          break;
+        }
+        default: {
+          // console.log("What is this crap are you feeding me!?")
+          break;
+        }
+      }
+      //console.log(auth)
+      // auth = auth // As expected, this didn't work, lol. Shame.
+    })
+     */
   }
 </script>

--- a/src/pages/Setup.svelte
+++ b/src/pages/Setup.svelte
@@ -5,8 +5,9 @@
   import '@firebase/auth'
   import { Link } from 'svelte-routing'
   import { providerDeciperer } from './../components/providerDeciperer.svelte'
+  import { auth } from './../auth.js'
   export const language = 'en'
-
+  
   const step = 1
   let user = ''
   let provider = '' // Use this to see which account is signed in.
@@ -36,6 +37,8 @@
         // console.log(result.user) // firebase.auth().onAuthStateChanged(function(u) {... Gets the same stuff.
         // console.log(result)
         providerDeciperer(result)
+        console.log("Auth store data is... ")
+        console.log({$auth})
       }) 
   } 
 


### PR DESCRIPTION
Took me a bit to wrap my head around this!

I noticed that my auto formatter was inserting semi-colons, and swapping out '' for "" in imports! Had to manually fix that... I'll go into my formatter's settings later after sleeping. 

When the function from providerDecriperer.svelte is called via the signIn fucntion in SetUp.svelte , it writes all of the user data we're interested in to auth.js.

Access those data from any other svelte pages by adding `import { auth } from './../auth'` to the top, then you can read the object via `{$auth}` anywhere else in the page. 

Reminder: Svelte.store data doesn't persist across page refreshes! 